### PR TITLE
Bug fixes, new --config-file option, and external ip lookup "interface"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Configuration goes in `dhdynupdate.conf`, and is in the [Python 'config' file fo
 ###`Global`
 This section has global configuration options:
 
-* Network interfaces to update the DNS records for. Empty string interfaces are ignored.
+* Network interfaces to update the DNS records for. Empty string interfaces are ignored. The special interface "-ipify.org" performs an external lookup.
 * [The DreamHost Web API URL](http://wiki.dreamhost.com/Application_programming_interface), and the logfile location.
 
 ###`DreamHost API Test Account`

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Configuration goes in `dhdynupdate.conf`, and is in the [Python 'config' file fo
 ###`Global`
 This section has global configuration options:
 
-* Network interfaces to update the DNS records for
+* Network interfaces to update the DNS records for. Empty string interfaces are ignored.
 * [The DreamHost Web API URL](http://wiki.dreamhost.com/Application_programming_interface), and the logfile location.
 
 ###`DreamHost API Test Account`

--- a/dhdns.py
+++ b/dhdns.py
@@ -113,8 +113,12 @@ class dhdns():
                     # Multiple entries may, if we're using native dual-stack IPv4 &
                     # IPv6.
                     if entry["record"] == self.local_hostname:
-                        logging.debug("Editable value:  %s" % entry)
-                        target_records.append(entry)
+                        # Ignore CNAME,NS,PTR,NAPTR,SRV, and TXT records
+                        if entry['type'] not in ["CNAME","NS","PTR","NAPTR","SRV","TXT"]:
+                            logging.debug("Editable value:  %s" % entry)
+                            target_records.append(entry)
+                        else:
+                            logging.info("Ignoring %s.%s record" % (entry["record"], entry["type"]))
             else: # read-only entry
                 logging.debug("Non-editable value:  %s" % entry)
                 if "record" in entry:

--- a/dhdynupdate.py
+++ b/dhdynupdate.py
@@ -119,6 +119,8 @@ def main(argv=None):
         # Technically, logger isn't "configured" -- it'll dump messages to the
         # console.
         print("Could not find configuration for %s" % (error))
+        print("Create a configuration for this account, or specify a different "+
+              "account with '-c'")
 #        logging.critical("Could not find configuration for %s" % (error))
         sys.exit(4)
     except:

--- a/dhdynupdate.py
+++ b/dhdynupdate.py
@@ -82,9 +82,9 @@ def main(argv=None):
 
     # read configuration from file
     config = configparser.ConfigParser()
-    try:
-        config.read("/etc/dhdynupdate.conf")
-    except:
+    if len(config.read("/etc/dhdynupdate.conf")) != 1:
+        # Behavior of configparser.read() is to fail silently,
+        #  returning an empty list of config filenames.
         print("Error reading config file!")
         sys.exit(3)
 

--- a/dhdynupdate.py
+++ b/dhdynupdate.py
@@ -118,7 +118,8 @@ def main(argv=None):
         pid_file = config["Global"]["pidfile"]
         for addr_type in supported_address_families:
             interface = config["Global"][addr_type]
-            if interface in netifaces.interfaces():
+            # Accept valid interfaces and special external lookup "interface"
+            if interface in netifaces.interfaces() or interface == "-ipify.org":
                 configured_interfaces[addr_type] = interface
     except KeyError as error:
         # Technically, logger isn't "configured" -- it'll dump messages to the

--- a/dhdynupdate.py
+++ b/dhdynupdate.py
@@ -73,6 +73,11 @@ def main(argv=None):
                             default="WARNING", required=False,
                             dest="log_level", metavar="lvl",
                             help="Log Level, one of CRITICAL, ERROR, WARNING, INFO, DEBUG")
+    cmd_parser.add_argument("-f", "--config-file", action='store',
+                            type=str, default="/etc/dhdynupdate.conf",
+                            required=False, metavar="path",
+                            dest="configfile_path",
+                            help="Configuration file path")
     cmd_parser.add_argument("-c", "--config", action='store',
                             type=str, default="DreamHost API Test Account",
                             required=False, metavar="config",
@@ -82,7 +87,7 @@ def main(argv=None):
 
     # read configuration from file
     config = configparser.ConfigParser()
-    if len(config.read("/etc/dhdynupdate.conf")) != 1:
+    if len(config.read(args.configfile_path)) != 1:
         # Behavior of configparser.read() is to fail silently,
         #  returning an empty list of config filenames.
         print("Error reading config file!")


### PR DESCRIPTION
Bug Fixes: in config parsing and domains with TXT records.
Improvements: Clarified some behaviors in error messages and README.
New Features: --config-file option, external lookup at ipify.org.

If you like the fixes and improvements but don't want one/both of the extensions, I'll happily make a new PR without them.

Both extensions are documented. The external lookup is implemented with a special "-ipify.org" "interface" name and a GET request from the interfaces class.

Thanks for the helpful software! :)